### PR TITLE
Ajout d'un test unitaire pour la fonction toLocalISOString et réusinage

### DIFF
--- a/src/vs/base/common/date.ts
+++ b/src/vs/base/common/date.ts
@@ -14,8 +14,12 @@ function pad(number: number): string {
 }
 
 export function toLocalISOString(date: Date): string {
+	// In JavaScript, the month of a date is between 0 and 11,
+	// so we need to add one in order to show it correctly to users
+	const MONHT_SHIFT = 1;
+
 	return date.getFullYear() +
-		'-' + pad(date.getMonth() + 1) +
+		'-' + pad(date.getMonth() + MONHT_SHIFT) +
 		'-' + pad(date.getDate()) +
 		'T' + pad(date.getHours()) +
 		':' + pad(date.getMinutes()) +

--- a/src/vs/base/common/date.ts
+++ b/src/vs/base/common/date.ts
@@ -16,10 +16,10 @@ function pad(number: number): string {
 export function toLocalISOString(date: Date): string {
 	// In JavaScript, the month of a date is between 0 and 11,
 	// so we need to add one in order to show it correctly to users
-	const MONHT_SHIFT = 1;
+	const MONTH_SHIFT = 1;
 
 	return date.getFullYear() +
-		'-' + pad(date.getMonth() + MONHT_SHIFT) +
+		'-' + pad(date.getMonth() + MONTH_SHIFT) +
 		'-' + pad(date.getDate()) +
 		'T' + pad(date.getHours()) +
 		':' + pad(date.getMinutes()) +

--- a/src/vs/base/test/common/date.test.ts
+++ b/src/vs/base/test/common/date.test.ts
@@ -1,0 +1,17 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+'use strict';
+
+import * as assert from 'assert';
+import { toLocalISOString } from 'vs/base/common/date';
+
+suite('Date.toLocalISOString', () => {
+	test('returns a date formatted according to ISO', () => {
+		const date = new Date(2018, 4, 15, 12, 50, 51, 356);
+		const dateString = toLocalISOString(date);
+
+		assert.equal(dateString, '2018-05-15T12:50:51.356Z');
+	});
+});


### PR DESCRIPTION
Ce _commit_ permet de résoudre la demande #1.

J'ai ajouté un test unitaire qui exerce spécifiquement l'addition de la constante et j'ai extrait cette constante afin d'en expliquer l'utilité.